### PR TITLE
Add missing configuration parsers for Content and User Settings views

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/ContentCreateView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/ContentCreateView.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+
+class ContentCreateView extends View
+{
+    public const NODE_KEY = 'content_create_view';
+    public const INFO = 'Template selection settings when creating content';
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/ContentEditView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/ContentEditView.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+
+class ContentEditView extends View
+{
+    public const NODE_KEY = 'content_edit_view';
+    public const INFO = 'Template selection settings when editing content';
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/SearchView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/SearchView.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+
+class SearchView extends View
+{
+    public const NODE_KEY = 'search_view';
+    public const INFO = 'Template selection settings when displaying search results';
+}

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/UserSettingsUpdateView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/UserSettingsUpdateView.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+
+class UserSettingsUpdateView extends View
+{
+    public const NODE_KEY = 'user_settings_update_view';
+    public const INFO = 'Template selection settings when updating user settings';
+}


### PR DESCRIPTION
Added the following configuration parsers that were missing:
- ContentEditView.php
- ContentCreateView.php
- UserSettingsUpdateView.php
- SearchView.php

These parsers are required for proper configuration handling in EZ Platform installations and prevent 'class not found' errors when loading the dependency injection container.

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes/no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
