### PR TITLE
Fix vendor paths: Replace ezsystems with se7enxweb paths

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -1,5 +1,5 @@
 parameters:
-    ezpublish.kernel.root_dir: "%kernel.project_dir%/vendor/ezsystems/ezplatform-kernel"
+    ezpublish.kernel.root_dir: "%kernel.project_dir%/vendor/se7enxweb/ezplatform-kernel"
 
     # API
     ezplatform.kernel.proxy_cache_dir: '%kernel.cache_dir%/repository/proxy'

--- a/eZ/Bundle/EzPublishCoreBundle/behat_suites.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/behat_suites.yml
@@ -4,20 +4,20 @@ core:
     suites:
         console:
             paths:
-                - vendor/ezsystems/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Console
+                - vendor/se7enxweb/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Console
             contexts:
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ConsoleContext
         web:
             paths:
-                - vendor/ezsystems/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Content
-                - vendor/ezsystems/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Exception
+                - vendor/se7enxweb/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Content
+                - vendor/se7enxweb/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/Exception
             contexts:
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentPreviewContext
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ContentContext
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\ExceptionContext
         query_controller:
             paths:
-                - vendor/ezsystems/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
+                - vendor/se7enxweb/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
             contexts:
                 - Behat\MinkExtension\Context\MinkContext
                 - eZ\Bundle\EzPublishCoreBundle\Features\Context\QueryControllerContext
@@ -25,7 +25,7 @@ core:
                 - EzSystems\Behat\API\Context\TestContext
         setup:
             paths:
-                - vendor/ezsystems/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/setup.feature
+                - vendor/se7enxweb/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/setup.feature
             contexts:
                 - EzSystems\Behat\API\Context\ContentContext
                 - EzSystems\Behat\API\Context\TestContext


### PR DESCRIPTION
- Update kernel root directory path in papi.yml configuration
- Fix behat suite paths to point to se7enxweb vendor directory
- Resolves path-based errors in folder creation and other operations
- Critical fix for 3.2++ release compatibility

Files updated:
- eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
- eZ/Bundle/EzPublishCoreBundle/behat_suites.yml

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes/no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
