### PR TITLE
fix: skip doctrine:database:create for SQLite in checkCreateDatabase()

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -131,6 +131,21 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
 
     private function checkCreateDatabase(OutputInterface $output)
     {
+        // SQLite creates the database file automatically on first connection; running
+        // doctrine:database:create --if-not-exists against SQLite throws a DBALException
+        // ("getListDatabasesSQL is not supported") because SQLite has no concept of
+        // server-side databases.  Skip the sub-command entirely for SQLite.
+        if ($this->connection->getDatabasePlatform()->getName() === 'sqlite') {
+            $output->writeln(
+                sprintf(
+                    'SQLite: database file <comment>%s</comment> will be created automatically on first connection.',
+                    $this->connection->getDatabase()
+                )
+            );
+
+            return;
+        }
+
         $output->writeln(
             sprintf(
                 'Creating database <comment>%s</comment> if it does not exist, using doctrine:database:create --if-not-exists',


### PR DESCRIPTION
SQLite creates the database file automatically on first PDO connection. Running 'doctrine:database:create --if-not-exists' against SQLite throws a Doctrine\DBAL\Exception: 'getListDatabasesSQL is not supported by platform.' This produced confusing error output during every SQLite install, even though the install succeeded.

Fix: detect the sqlite platform in checkCreateDatabase() and return early with an informational message instead of running the unsupported sub-command.

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-XXXX](https://issues.ibexa.co/browse/IBX-XXXX)
| **Type**                                   | feature/bug/improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes/no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
